### PR TITLE
changing os.rename to shutil.move on --format=dir parameter

### DIFF
--- a/platter.py
+++ b/platter.py
@@ -377,7 +377,7 @@ class Builder(object):
         if format == 'dir':
             rv_fn = os.path.join(self.output, base)
             self.log.info('Saving artifact as directory {}', rv_fn)
-            os.rename(scratchpad, rv_fn)
+            shutil.move(scratchpad, rv_fn)
             return rv_fn
 
         archive_name = base + '.' + format


### PR DESCRIPTION
on os.rename I found two errors:
when dest directory is not empty raises: 'OSError: [Errno 39] Directory not empty'
but with shutil.move it overwrite the directory.

when dest dir is not in the same hd partition of /tmp raises: 'OSError: [Errno 18] Invalid cross-device link'
but with shutil.move it dont occurs.

by Diogo Dutra dutradda@gmail.com
