### PR TITLE
Call describe_package() after prebuild script

### DIFF
--- a/platter.py
+++ b/platter.py
@@ -81,9 +81,10 @@ DATA_DIR="$HERE/data"
 # Ensure Python exists
 command -v "$py" &> /dev/null || error "Given python interpreter not found ($py)"
 
-echo 'Setting up virtualenv'
-"$py" "$DATA_DIR/virtualenv.py" "$1"
-VIRTUAL_ENV="$(cd "$1"; pwd)"
+if [ ! -d "$1" ]; then
+  echo 'Setting up virtualenv'
+  "$py" "$DATA_DIR/virtualenv.py" "$1"
+  VIRTUAL_ENV="$(cd "$1"; pwd)"
 
 INSTALL_ARGS=''
 if [ -f "$DATA_DIR/requirements.txt" ]; then

--- a/platter.py
+++ b/platter.py
@@ -529,12 +529,6 @@ class Builder(object):
         venv_path = self.setup_build_venv(venv_src)
         local_python = os.path.join(venv_path, 'bin', 'python')
 
-        self.log.info('Analyzing package')
-        pkginfo = self.describe_package(local_python)
-        with self.log.indented():
-            self.log.info('Name: {}', pkginfo['name'])
-            self.log.info('Version: {}', pkginfo['version'])
-
         scratchpad = self.make_scratchpad('buildbase')
         data_dir = os.path.join(scratchpad, 'data')
         os.makedirs(data_dir)
@@ -545,6 +539,12 @@ class Builder(object):
         if prebuild_script is not None:
             self.run_build_script(scratchpad, venv_path, prebuild_script,
                                   install_script_path)
+
+        self.log.info('Analyzing package')
+        pkginfo = self.describe_package(local_python)
+        with self.log.indented():
+            self.log.info('Name: {}', pkginfo['name'])
+            self.log.info('Version: {}', pkginfo['version'])
 
         self.build_wheels(venv_path, data_dir)
         self.put_meta_info(scratchpad, pkginfo)

--- a/platter.py
+++ b/platter.py
@@ -256,13 +256,13 @@ class Builder(object):
                                   stdout=subprocess.PIPE,
                                   stderr=subprocess.PIPE)
             if capture:
-                rv = cl.communicate()[0]
+                rv, err = cl.communicate()
             else:
                 rv = None
                 self.log.process_stream_output(cl)
 
             if cl.wait() != 0:
-                self.log.error('Failed to execute command "%s"' % cmd)
+                self.log.error('Failed to execute command "%s": %s' % (cmd, err))
                 raise click.Abort()
             return rv
 

--- a/platter.py
+++ b/platter.py
@@ -81,10 +81,9 @@ DATA_DIR="$HERE/data"
 # Ensure Python exists
 command -v "$py" &> /dev/null || error "Given python interpreter not found ($py)"
 
-if [ ! -d "$1" ]; then
-  echo 'Setting up virtualenv'
-  "$py" "$DATA_DIR/virtualenv.py" "$1"
-  VIRTUAL_ENV="$(cd "$1"; pwd)"
+echo 'Setting up virtualenv'
+"$py" "$DATA_DIR/virtualenv.py" "$1"
+VIRTUAL_ENV="$(cd "$1"; pwd)"
 
 INSTALL_ARGS=''
 if [ -f "$DATA_DIR/requirements.txt" ]; then


### PR DESCRIPTION
This allows pre-setup dependencies of C extension modules to be satisfied before `setup.py --version` is run . Without this, extension modules that depend on, e.g., Cython or Numpy's C headers can't be built.

I should have included this as a part of #1. Sorry about the omission.
