### PR TITLE
Improved error handling in install script

### DIFF
--- a/platter.py
+++ b/platter.py
@@ -46,7 +46,7 @@ EOF
 param_error() {
   show_usage
   echo
-  echo "Error: $1"
+  echo "Error: $1" >&2
   exit 1
 }
 
@@ -79,7 +79,8 @@ HERE="$(cd "$(dirname "$0")"; pwd)"
 DATA_DIR="$HERE/data"
 
 # Ensure Python exists
-command -v "$py" &> /dev/null || error "Given python interpreter not found ($py)"
+command -v "$py" &> /dev/null || \
+  { echo "Given python interpreter not found ($py)" >&2; exit 1; }
 
 echo 'Setting up virtualenv'
 "$py" "$DATA_DIR/virtualenv.py" "$1"
@@ -93,6 +94,9 @@ fi
 echo "Installing %(name)s"
 "$VIRTUAL_ENV/bin/pip" install --pre --no-index \
   --find-links "$DATA_DIR" wheel $INSTALL_ARGS %(pkg)s | grep -v '^$'
+if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
+  exit 1
+fi
 
 # Potential post installation
 cd "$HERE"

--- a/platter.py
+++ b/platter.py
@@ -52,7 +52,7 @@ param_error() {
 
 py="%(python)s"
 
-while [ "$#" -gt 0 ]; do
+while [[ "$#" -gt 0 ]]; do
   case $1 in
     --help)         show_help ;;
     -p|--python)
@@ -71,7 +71,7 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
-if [ "$1" == "" ]; then
+if [[ "$1" == "" ]]; then
   param_error "destination argument is required"
 fi
 
@@ -87,7 +87,7 @@ echo 'Setting up virtualenv'
 VIRTUAL_ENV="$(cd "$1"; pwd)"
 
 INSTALL_ARGS=''
-if [ -f "$DATA_DIR/requirements.txt" ]; then
+if [[ -f "$DATA_DIR/requirements.txt" ]]; then
   INSTALL_ARGS="$INSTALL_ARGS"\ -r\ "$DATA_DIR/requirements.txt"
 fi
 


### PR DESCRIPTION
This fixes #11 as well as redirecting all errors to STDERR

Main gain is that a failed pip install now results in a non-success error code allowing this condition to be caught in deployment scripts.

There are still further failures possible and potentially a (rm -rf abuse safe) cleanup of a failed directory should be performed.

The second commit are minor bash improvements.